### PR TITLE
feat: use file extensions from collection names for MIME guessing

### DIFF
--- a/iroh-gateway/Cargo.lock
+++ b/iroh-gateway/Cargo.lock
@@ -2069,6 +2069,7 @@ dependencies = [
  "lru",
  "mime",
  "mime_classifier",
+ "mime_guess",
  "quinn",
  "range-collections",
  "rustls",
@@ -2423,6 +2424,16 @@ checksum = "e817cb34c89e147fcfbb8a4e88e4c1c064c1c9fcdab80191f94b55921b3cbbd4"
 dependencies = [
  "mime",
  "serde",
+]
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -4760,6 +4771,15 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/iroh-gateway/Cargo.toml
+++ b/iroh-gateway/Cargo.toml
@@ -30,3 +30,4 @@ tokio-rustls-acme = { version = "0.2.0", features = ["axum"] }
 hyper-util = "0.1.2"
 rustls-pemfile = "1.0.2"
 tower-service = "0.3.2"
+mime_guess = "2.0.4"


### PR DESCRIPTION
I was trying to serve a website (HTML and CSS) from an iroh collection with the `iroh-gateway` example. It works, but CSS is not applied to the page because the gateway serves CSS files with `text/plain`, which makes the browser ignore it.

The MIME guesser currently only uses the blob data to guess the mime type (via [mime_classifier](https://crates.io/crates/mime_classifier). This is insufficient in many cases (e.g. all text files will be `text/plain`).

This PR changes this so that for blobs served through collections, the extension of the filename from the collection metadata is used to guess the MIME type. If the file has no or an unknown extension, it falls back to the `mime_classifier`.

With this change, we can serve websites. At least basic static sites.