### PR TITLE
chore(ci): Update outdated actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -55,7 +55,7 @@ jobs:
         HOME: /root #added based on https://github.com/actions/setup-go/issues/116
     
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.4
 
     - name: check
       run: |


### PR DESCRIPTION
These actions use a deprecated nodejs version.  The newer versions do
not.

Also moves to released versions of actions/checkout as that's more
stable and the recommended way to use them.