### PR TITLE
update pkarr publish to also publish to relay

### DIFF
--- a/content-discovery/Cargo.lock
+++ b/content-discovery/Cargo.lock
@@ -1922,7 +1922,7 @@ name = "iroh-pkarr-node-discovery"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "futures",
+ "futures-lite",
  "genawaiter",
  "iroh-net",
  "pkarr",

--- a/content-discovery/Cargo.lock
+++ b/content-discovery/Cargo.lock
@@ -1923,6 +1923,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "futures",
+ "genawaiter",
  "iroh-net",
  "pkarr",
  "tokio",

--- a/content-discovery/iroh-mainline-content-discovery/src/client.rs
+++ b/content-discovery/iroh-mainline-content-discovery/src/client.rs
@@ -216,7 +216,9 @@ async fn create_endpoint(
     publish: bool,
 ) -> anyhow::Result<MagicEndpoint> {
     let mainline_discovery = if publish {
-        PkarrNodeDiscovery::builder().secret_key(key.clone()).build()?
+        PkarrNodeDiscovery::builder()
+            .secret_key(key.clone())
+            .build()?
     } else {
         PkarrNodeDiscovery::default()
     };

--- a/content-discovery/iroh-mainline-content-discovery/src/client.rs
+++ b/content-discovery/iroh-mainline-content-discovery/src/client.rs
@@ -216,7 +216,7 @@ async fn create_endpoint(
     publish: bool,
 ) -> anyhow::Result<MagicEndpoint> {
     let mainline_discovery = if publish {
-        PkarrNodeDiscovery::builder().secret_key(&key).build()
+        PkarrNodeDiscovery::builder().secret_key(key.clone()).build()?
     } else {
         PkarrNodeDiscovery::default()
     };

--- a/content-discovery/iroh-mainline-tracker/src/main.rs
+++ b/content-discovery/iroh-mainline-tracker/src/main.rs
@@ -70,7 +70,7 @@ async fn create_endpoint(
     publish: bool,
 ) -> anyhow::Result<MagicEndpoint> {
     let mainline_discovery = if publish {
-        PkarrNodeDiscovery::builder().secret_key(&key).build()
+        PkarrNodeDiscovery::builder().secret_key(key.clone()).build()?
     } else {
         PkarrNodeDiscovery::default()
     };

--- a/content-discovery/iroh-mainline-tracker/src/main.rs
+++ b/content-discovery/iroh-mainline-tracker/src/main.rs
@@ -70,7 +70,9 @@ async fn create_endpoint(
     publish: bool,
 ) -> anyhow::Result<MagicEndpoint> {
     let mainline_discovery = if publish {
-        PkarrNodeDiscovery::builder().secret_key(key.clone()).build()?
+        PkarrNodeDiscovery::builder()
+            .secret_key(key.clone())
+            .build()?
     } else {
         PkarrNodeDiscovery::default()
     };

--- a/iroh-pkarr-node-discovery/Cargo.lock
+++ b/iroh-pkarr-node-discovery/Cargo.lock
@@ -53,6 +53,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,10 +411,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
@@ -793,7 +887,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -1153,6 +1247,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1659,7 +1759,9 @@ name = "iroh-pkarr-node-discovery"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "clap",
  "futures",
+ "genawaiter",
  "hex",
  "iroh-net",
  "pkarr",
@@ -3396,6 +3498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "struct_iterable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,7 +3547,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3922,6 +4030,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "valuable"

--- a/iroh-pkarr-node-discovery/Cargo.lock
+++ b/iroh-pkarr-node-discovery/Cargo.lock
@@ -1760,7 +1760,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
- "futures",
+ "futures-lite",
  "genawaiter",
  "hex",
  "iroh-net",

--- a/iroh-pkarr-node-discovery/Cargo.toml
+++ b/iroh-pkarr-node-discovery/Cargo.toml
@@ -13,7 +13,7 @@ description = "A discovery mechanism for iroh-net that uses the bittorrent mainl
 
 [dependencies]
 anyhow = "1.0.79"
-futures = "0.3.30"
+futures-lite = "2.3.0"
 genawaiter = "0.99.1"
 iroh-net = "0.14.0"
 pkarr = { version = "1.0.1", features = ["async"] }

--- a/iroh-pkarr-node-discovery/Cargo.toml
+++ b/iroh-pkarr-node-discovery/Cargo.toml
@@ -14,12 +14,14 @@ description = "A discovery mechanism for iroh-net that uses the bittorrent mainl
 [dependencies]
 anyhow = "1.0.79"
 futures = "0.3.30"
+genawaiter = "0.99.1"
 iroh-net = "0.14.0"
 pkarr = { version = "1.0.1", features = ["async"] }
 tokio = "1.35.1"
 tracing = "0.1.40"
 
 [dev-dependencies]
+clap = { version = "4.5.4", features = ["derive"] }
 hex = "0.4.3"
 postcard = "1.0.8"
 proptest = "1.4.0"

--- a/iroh-pkarr-node-discovery/src/lib.rs
+++ b/iroh-pkarr-node-discovery/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Node discovery is being able to find connecting information about an iroh node based on just its node id.
 //!
-//! This crate implements a discovery mechanism for iroh-net based on <https://https://pkarr.org/>.
+//! This crate implements a discovery mechanism for iroh-net based on <https://pkarr.org/>.
 //!
 //! TLDR: Each node publishes its address to the mainline DHT as a DNS packet, signed with its private key.
 //! The DNS packet contains the node's direct addresses and optionally a DERP URL.
@@ -31,7 +31,7 @@ const REPUBLISH_DELAY: Duration = Duration::from_secs(60 * 60);
 /// frequent network changes at startup.
 const INITIAL_PUBLISH_DELAY: Duration = Duration::from_millis(500);
 
-/// A discovery mechanism for iroh-net based on <https://https://pkarr.org/>.
+/// A discovery mechanism for iroh-net based on <https://pkarr.org/>.
 ///
 /// TLDR: it stores node addresses in DNS records, signed by the node's private key,
 /// and publishes them to the bittorrent mainline DHT.

--- a/iroh-pkarr-node-discovery/src/lib.rs
+++ b/iroh-pkarr-node-discovery/src/lib.rs
@@ -223,7 +223,7 @@ impl PkarrNodeDiscovery {
                 }
             };
             // do both at the same time
-            futures::future::join(relay_publish, dht_publish).await;
+            tokio::join!(relay_publish, dht_publish);
             tokio::time::sleep(REPUBLISH_DELAY - INITIAL_PUBLISH_DELAY).await;
         }
     }
@@ -308,10 +308,10 @@ impl PkarrNodeDiscovery {
     async fn resolve(self, node_id: NodeId, co: Co<anyhow::Result<DiscoveryItem>>) {
         let pkarr_public_key =
             pkarr::PublicKey::try_from(*node_id.as_bytes()).expect("valid public key");
-        let resolve_dht = self.resolve_dht(pkarr_public_key.clone(), &co);
-        let resolve_relay = self.resolve_relay(pkarr_public_key, &co);
-        tokio::pin!(resolve_dht, resolve_relay);
-        futures::future::join(resolve_dht, resolve_relay).await;
+        tokio::join!(
+            self.resolve_dht(pkarr_public_key.clone(), &co),
+            self.resolve_relay(pkarr_public_key, &co)
+        );
     }
 }
 

--- a/iroh-pkarr-node-discovery/src/lib.rs
+++ b/iroh-pkarr-node-discovery/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 
-use futures::{stream::BoxStream, StreamExt};
+use futures_lite::StreamExt;
 use genawaiter::sync::{Co, Gen};
 use iroh_net::{
     discovery::{Discovery, DiscoveryItem},
@@ -340,7 +340,7 @@ impl Discovery for PkarrNodeDiscovery {
         &self,
         _endpoint: MagicEndpoint,
         node_id: NodeId,
-    ) -> Option<BoxStream<'_, anyhow::Result<DiscoveryItem>>> {
+    ) -> Option<futures_lite::stream::Boxed<anyhow::Result<DiscoveryItem>>> {
         let this = self.clone();
         let pkarr_public_key =
             pkarr::PublicKey::try_from(*node_id.as_bytes()).expect("valid public key");


### PR DESCRIPTION
also give more builder options, and use the now official pkarr record format.

This might soon move into iroh-net, but for now let's keep it here because it has so many options.