### PR TITLE
Add bao-http-tool example

### DIFF
--- a/bao-http-tool/Cargo.toml
+++ b/bao-http-tool/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "http-tool"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.82"
+bao-tree = "0.13.0"
+clap = { version = "4.5.4", features = ["derive"] }
+iroh-io = { version = "0.6.0", features = ["x-http", "stats", "tokio-util"] }
+tokio = { version = "1.37.0", features = ["full"] }
+tokio-util = "0.7.10"
+url = "2.5.0"

--- a/bao-http-tool/README.md
+++ b/bao-http-tool/README.md
@@ -1,0 +1,17 @@
+# Validate external data using external outboard
+
+## Usage
+
+To test this, run a http dev server that supports range requests in your iroh data dir.
+
+The outboard data must be *without* length prefix.
+
+```
+RUST_LOG=debug \
+  cargo run -- \
+  --hash 370e2b3002be3b38b120f7b3be53da4cf646810e26f8f4a5018247c8188af5b2 \
+  --block-size-log 4
+  --url http://127.0.0.1:3003/370e2b3002be3b38b120f7b3be53da4cf646810e26f8f4a5018247c8188af5b2.data
+  --outboard http://127.0.0.1:3003/370e2b3002be3b38b120f7b3be53da4cf646810e26f8f4a5018247c8188af5b2.obao4
+  --range 0..10000000
+```

--- a/bao-http-tool/src/args.rs
+++ b/bao-http-tool/src/args.rs
@@ -1,0 +1,74 @@
+use std::{fmt::Display, path::PathBuf, str::FromStr};
+
+use bao_tree::blake3::Hash;
+use clap::Parser;
+use url::Url;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    #[clap(subcommand)]
+    pub subcommand: SubCommand,
+}
+
+#[derive(Debug, Parser)]
+pub enum SubCommand {
+    Validate(ValidateArgs),
+    Generate(GenerateArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct ValidateArgs {
+    #[clap(long, help = "Hash of the data")]
+    pub hash: Hash,
+
+    #[clap(long, help = "URL or local path to the data")]
+    pub data: PathOrUrl,
+
+    #[clap(long, help = "URL or local path to the outboard")]
+    pub outboard: PathOrUrl,
+
+    #[clap(long, default_value_t = 0, help = "Block size in log2(bytes)")]
+    pub block_size_log: u8,
+
+    #[clap(long, help = "Range of the data to read")]
+    pub range: Option<String>,
+}
+
+#[derive(Debug, Parser)]
+pub struct GenerateArgs {
+    #[clap(long, help = "URL to the data")]
+    pub data: Url,
+
+    #[clap(long, help = "path where to create the outboard")]
+    pub target: Option<PathBuf>,
+
+    #[clap(long, default_value_t = 0, help = "Block size in log2(bytes)")]
+    pub block_size_log: u8,
+}
+
+#[derive(Debug, Clone)]
+pub enum PathOrUrl {
+    Path(std::path::PathBuf),
+    Url(Url),
+}
+
+impl Display for PathOrUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PathOrUrl::Path(path) => write!(f, "{}", path.display()),
+            PathOrUrl::Url(url) => write!(f, "{}", url),
+        }
+    }
+}
+
+impl FromStr for PathOrUrl {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(url) = Url::from_str(s) {
+            Ok(PathOrUrl::Url(url))
+        } else {
+            Ok(PathOrUrl::Path(std::path::PathBuf::from(s)))
+        }
+    }
+}

--- a/bao-http-tool/src/main.rs
+++ b/bao-http-tool/src/main.rs
@@ -1,0 +1,99 @@
+use std::io::Cursor;
+
+use bao_tree::{
+    io::{fsm::encode_ranges_validated, round_up_to_chunks},
+    BaoTree, BlockSize, ByteRanges,
+};
+use clap::Parser;
+use iroh_io::{AsyncSliceReader, HttpAdapter};
+use tokio_util::either::Either;
+mod args;
+use args::{GenerateArgs, PathOrUrl, SubCommand, ValidateArgs};
+
+use crate::args::Args;
+
+type Reader = Either<iroh_io::HttpAdapter, iroh_io::File>;
+
+async fn open(path: PathOrUrl) -> anyhow::Result<Reader> {
+    Ok(match path {
+        PathOrUrl::Url(url) => Either::Left(iroh_io::HttpAdapter::new(url)),
+        PathOrUrl::Path(path) => Either::Right(iroh_io::File::open(path).await?),
+    })
+}
+
+async fn generate(args: GenerateArgs) -> anyhow::Result<()> {
+    let mut outboard = Vec::new();
+    let mut data = HttpAdapter::new(args.data.clone());
+    let block_size = BlockSize::from_chunk_log(args.block_size_log);
+    let size = data.size().await?;
+    let tree = BaoTree::new(size, block_size);
+    println!(
+        "Computing outboard for {} of size {} with block size {}",
+        args.data, size, block_size
+    );
+    let hash =
+        bao_tree::io::fsm::outboard_post_order(Cursor::new(data), tree, &mut outboard).await?;
+    println!("Computed hash: {}", hash.to_hex());
+    let filename = args
+        .target
+        .unwrap_or_else(|| format!("{}.obao{}", hash.to_hex(), block_size.chunk_log()).into());
+    println!("Writing outboard to {}", filename.display());
+    tokio::fs::write(filename, outboard).await?;
+    Ok(())
+}
+
+async fn validate(args: ValidateArgs) -> anyhow::Result<()> {
+    let mut data = open(args.data.clone()).await?;
+    let mut outboard = open(args.outboard.clone()).await?;
+    let size = data.size().await?;
+    let outboard_size = outboard.size().await?;
+    let byte_ranges = if let Some(range) = args
+        .range
+        .as_ref()
+        .map(|x| x.split("..").collect::<Vec<_>>())
+    {
+        if range.len() != 2 {
+            anyhow::bail!("Invalid range");
+        }
+        let start: u64 = range[0].parse()?;
+        let end: u64 = range[1].parse()?;
+        ByteRanges::from(start..end)
+    } else {
+        ByteRanges::all()
+    };
+    let chunk_ranges = round_up_to_chunks(&byte_ranges);
+    // let size = outboard.read_at(0, 8).await?;
+    // let size = u64::from_le_bytes(size.as_ref().try_into()?);
+    let block_size = BlockSize::from_chunk_log(args.block_size_log);
+    println!("Size: {}", size);
+    println!("Outboard: {}", outboard_size);
+    println!("Hash: {}", args.hash.to_hex());
+    println!("Block size: {}", block_size);
+    println!("Byte ranges: {:?}", byte_ranges);
+    println!("Chunk ranges: {:?}", chunk_ranges);
+    let tree = BaoTree::new(size, block_size);
+    let outboard = bao_tree::io::outboard::PreOrderOutboard {
+        root: args.hash,
+        data: outboard,
+        tree,
+    };
+    let encoded = Vec::new();
+    encode_ranges_validated(data, outboard, &chunk_ranges, encoded).await?;
+    println!(
+        "confirmed that range {:?} of {} matches {}",
+        byte_ranges,
+        args.data,
+        args.hash.to_hex()
+    );
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    match args.subcommand {
+        SubCommand::Validate(args) => validate(args).await?,
+        SubCommand::Generate(args) => generate(args).await?,
+    }
+    Ok(())
+}

--- a/validate-http/Cargo.toml
+++ b/validate-http/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bao-http-tool"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.82"
+bao-tree = "0.13.0"
+clap = { version = "4.5.4", features = ["derive"] }
+iroh-io = { version = "0.6.0", features = ["x-http", "stats", "tokio-util"] }
+tokio = { version = "1.37.0", features = ["full"] }
+tokio-util = "0.7.10"
+url = "2.5.0"


### PR DESCRIPTION
create outboards from remote files
validate a range of a remote file using a local or remote outboard

Not sure if this should be in bao-tree? But nobody looks there? 🤷 