### PR TITLE
fix(ci): remove doc-photos from checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.75"
-  RS_EXAMPLES_LIST: "content-discovery,doc-photos,dumbpipe-web,extism/host,extism/iroh-extism-host-functions,extism/plugin,iroh-automerge,iroh-gateway,iroh-pkarr-naming-system,iroh-pkarr-node-discovery,iroh-s3-bao-store"
+  RS_EXAMPLES_LIST: "content-discovery,dumbpipe-web,extism/host,extism/iroh-extism-host-functions,extism/plugin,iroh-automerge,iroh-gateway,iroh-pkarr-naming-system,iroh-pkarr-node-discovery,iroh-s3-bao-store"
   GO_EXAMPLES_LIST: "dall_e_worker"
 
 jobs:


### PR DESCRIPTION
#46 missed removing this from checks (thus the failing status in the PR) 