### PR TITLE
`iroh-gateway`: add support for passing node ticket or node id to --default-node

### DIFF
--- a/iroh-gateway/src/main.rs
+++ b/iroh-gateway/src/main.rs
@@ -25,7 +25,7 @@ use iroh::{
         Hash,
     },
     net::{MagicEndpoint, NodeAddr},
-    ticket::BlobTicket,
+    ticket::{BlobTicket, NodeTicket},
 };
 use lru::LruCache;
 use mime::Mime;
@@ -518,7 +518,7 @@ async fn main() -> anyhow::Result<()> {
         .default_node
         .map(|default_node| {
             Ok(
-                if let Ok(node_ticket) = default_node.parse::<BlobTicket>() {
+                if let Ok(node_ticket) = default_node.parse::<NodeTicket>() {
                     node_ticket.node_addr().clone()
                 } else if let Ok(blob_ticket) = default_node.parse::<BlobTicket>() {
                     blob_ticket.node_addr().clone()


### PR DESCRIPTION
- Fixes typo that prevented node tickets from being parsed
- Enables node discovery and adds raw node id to list of parsers tried for --default-node arg