### PR TITLE
docs: improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,33 +7,39 @@ For very experimental things there is [iroh-experiments].
 
 ## Examples
 
-# Dumbpipe-web
+### [browser-echo](browser-echo)
+
+Use iroh in the browser, compiled to web assembly. [Try it here!](https://n0-computer.github.io/iroh-examples/main/browser-echo/index.html)
+
+### [browser-chat](browser-chat)
+
+A chat app based on iroh-gossip that can run both in the browser and on the command line.
+[Try it here!](https://n0-computer.github.io/iroh-examples/main/browser-echo/index.html)
+
+### [dumbpipe-web](dumbpipe-web)
 
 Forward http requests to dumbpipe. Share a local dev server publicly.
 
-# Extism
+### [extism](extism)
 
 Use iroh through [extism]
 
-# Iroh-automerge
+### [frosty](frosty)
+
+Experiment with [FROST] threshold signatures for iroh.
+
+### [iroh-automerge](iroh-automerge)
 
 Iroh integration with [automerge]
 
-# Iroh-gateway
+### [iroh-gateway](iroh-gateway)
 
 A http gateway for iroh-blobs data, written using iroh-blobs.
 
-# Iroh-pkarr-node-discovery
+### [tauri-todos](tauri-todos)
 
-Node discovery using the bittorrent [mainline] DHT and [pkarr].
+Todo app using iroh documents and [tauri].
 
-# Tauri-todos
-
-Todo app using iroh documents and [tauri]
-
-# Browser-echo
-
-Use iroh in the browser, compiled to web assembly.
 
 [iroh-experiments]: https://github.com/n0-computer/iroh-experiments
 [extism]: https://extism.org/
@@ -41,3 +47,4 @@ Use iroh in the browser, compiled to web assembly.
 [mainline]: https://en.wikipedia.org/wiki/Mainline_DHT
 [pkarr]: https://pkarr.org/
 [tauri]: https://tauri.app/
+[FROST]: https://eprint.iacr.org/2020/852.pdf

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use iroh in the browser, compiled to web assembly. [Try it here!](https://n0-com
 ### [browser-chat](browser-chat)
 
 A chat app based on iroh-gossip that can run both in the browser and on the command line.
-[Try it here!](https://n0-computer.github.io/iroh-examples/main/browser-echo/index.html)
+[Try it here!](https://n0-computer.github.io/iroh-examples/main/browser-chat/index.html)
 
 ### [dumbpipe-web](dumbpipe-web)
 

--- a/browser-chat/README.md
+++ b/browser-chat/README.md
@@ -2,6 +2,8 @@
 
 This is a chat app that runs in both the browser and the command line. It uses [`iroh-gossip`](https://github.com/n0-computer/iroh-gossip/) to send messages between peers sharing a channel.
 
+We automatically deploy this example, you can **[try it out here](https://n0-computer.github.io/iroh-examples/main/browser-chat/index.html)**.
+
 The example has the following parts:
 
 * [**shared**](shared) is a Rust library that exposes a `ChatNode`, which uses iroh and iroh-gossip to power a simple ephemeral gossip chat between peers.

--- a/browser-echo/README.md
+++ b/browser-echo/README.md
@@ -6,6 +6,9 @@ The protocol and setup code is shared between the browser and the CLI.
 
 ## Run the browser version:
 
+You can try out the **[deployed example](https://n0-computer.github.io/iroh-examples/main/browser-echo/index.html)**.
+To build and run it yourself, follow these steps:
+
 ```sh
 $ cargo install wasm-bindgen-cli
 $ rustup target install wasm32-unknown-unknown


### PR DESCRIPTION
This improves the readme:

* Make headings smaller
* Add links to the examples

Also adds links to the deployed browser examples.