### PR TITLE
fix: Define more precisely which wasm features are needed

### DIFF
--- a/browser-chat/browser-wasm/Cargo.toml
+++ b/browser-chat/browser-wasm/Cargo.toml
@@ -22,4 +22,4 @@ wasm-bindgen-futures = "0.4"
 wasm-streams = "0.4.2"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["--all-features"]
+wasm-opt = ["--enable-nontrapping-float-to-int", "--enable-bulk-memory"]

--- a/browser-chat/shared/Cargo.toml
+++ b/browser-chat/shared/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "1", default-features = false, features = ["sync"] }
 tracing = "0.1"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["--all-features"]
+wasm-opt = ["--enable-nontrapping-float-to-int", "--enable-bulk-memory"]

--- a/browser-echo/package.json
+++ b/browser-echo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build": "cargo build --target=wasm32-unknown-unknown && wasm-bindgen ./target/wasm32-unknown-unknown/debug/browser_echo.wasm --out-dir=public/wasm --weak-refs --target=web --debug",
-    "build:release": "cargo build --target=wasm32-unknown-unknown --release && wasm-bindgen ./target/wasm32-unknown-unknown/release/browser_echo.wasm --out-dir=public/wasm --weak-refs --target=web && wasm-opt --all-features -Os -o public/wasm/browser_echo_bg.wasm public/wasm/browser_echo_bg.wasm",
+    "build:release": "cargo build --target=wasm32-unknown-unknown --release && wasm-bindgen ./target/wasm32-unknown-unknown/release/browser_echo.wasm --out-dir=public/wasm --weak-refs --target=web && wasm-opt --enable-nontrapping-float-to-int --enable-bulk-memory -Os -o public/wasm/browser_echo_bg.wasm public/wasm/browser_echo_bg.wasm",
     "serve": "http-server --cors -a localhost public/"
   },
   "author": "n0 team",


### PR DESCRIPTION
We used to get an unhelpful message
> [wasm-validator error in function 12234] unexpected false: all used features should be allowed, on [...]

Turns out we need to `--enable-nontrapping-float-to-int`.
Together with `--enable-bulk-memory` this is enough to get the build going (without `--all-features`).

So I'm following [the recommendation](https://github.com/WebAssembly/binaryen/issues/7228#issuecomment-3086568779) and specify the needed features precisely.